### PR TITLE
一种更好的启动 Shizuku Server 的方式

### DIFF
--- a/manager/build.gradle
+++ b/manager/build.gradle
@@ -25,6 +25,16 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    externalNativeBuild {
+        cmake {
+            path 'src/main/jni/CMakeLists.txt'
+        }
+    }
+    sourceSets {
+        main {
+            jniLibs.srcDirs 'build/starter'
+        }
+    }
 }
 
 configurations {

--- a/manager/build.gradle
+++ b/manager/build.gradle
@@ -34,6 +34,7 @@ android {
     }
     sourceSets {
         main {
+            // executable files output directory defined in src/main/jni/CMakeList.txt
             jniLibs.srcDirs 'build/starter'
         }
     }

--- a/manager/src/main/java/moe/shizuku/privileged/api/ServerLauncher.java
+++ b/manager/src/main/java/moe/shizuku/privileged/api/ServerLauncher.java
@@ -157,11 +157,24 @@ public class ServerLauncher {
 
             String path = context.getPackageManager().getApplicationInfo(context.getPackageName(), 0).publicSourceDir;
 
+            File dir = new File(path);
+            File starter = new File(dir.getParentFile(), "lib/*/libshizuku.so");
+            String starterPath = starter.getAbsolutePath();
+
             BufferedWriter os = new BufferedWriter(new FileWriter(file));
             os.write("#!/system/bin/sh\n");
-            os.write("if [ -f " + path + " ]\n");
+            os.write("if [ -f " + starterPath + " ]\n");
             os.write("then\n");
-            os.write("\texec app_process -Djava.class.path=" + path + " /system/bin --nice-name=rikka_server moe.shizuku.server.Server &");
+            //os.write("\texec app_process -Djava.class.path=" + path + " /system/bin --nice-name=rikka_server moe.shizuku.server.Server &\n");
+
+            final String starterName = "shizuku_starter";
+            final String tmpPath = "/data/local/tmp";
+            os.write(String.format("\trm %s/%s\n", tmpPath, starterName));
+            os.write(String.format("\tcp %s %s/%s\n", starterPath, tmpPath, starterName));
+            os.write(String.format("\tchmod +x %s/%s\n", tmpPath, starterName));
+            os.write(String.format("\texport PATH=%s:/system/bin:$PATH\n", tmpPath));
+            os.write(String.format("\t%s\n", starterName));
+
             os.write("else\n");
             os.write("\techo \"Apk file not exist, please open Shizuku Manager and try again.\"\n");
             os.write("fi\n");

--- a/manager/src/main/java/moe/shizuku/privileged/api/ServerLauncher.java
+++ b/manager/src/main/java/moe/shizuku/privileged/api/ServerLauncher.java
@@ -10,10 +10,12 @@ import android.support.annotation.IntDef;
 import android.support.annotation.WorkerThread;
 import android.util.Log;
 
-import java.io.BufferedWriter;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.net.Socket;
@@ -157,27 +159,17 @@ public class ServerLauncher {
 
             String path = context.getPackageManager().getApplicationInfo(context.getPackageName(), 0).publicSourceDir;
 
-            File dir = new File(path);
-            File starter = new File(dir.getParentFile(), "lib/*/libshizuku.so");
+            File sourceDir = new File(path);
+            File libDir = new File(sourceDir.getParentFile(), "lib").listFiles()[0];
+            File starter = new File(libDir, "libshizuku.so");
             String starterPath = starter.getAbsolutePath();
 
-            BufferedWriter os = new BufferedWriter(new FileWriter(file));
-            os.write("#!/system/bin/sh\n");
-            os.write("if [ -f " + starterPath + " ]\n");
-            os.write("then\n");
-            //os.write("\texec app_process -Djava.class.path=" + path + " /system/bin --nice-name=rikka_server moe.shizuku.server.Server &\n");
-
-            final String starterName = "shizuku_starter";
-            final String tmpPath = "/data/local/tmp";
-            os.write(String.format("\trm %s/%s\n", tmpPath, starterName));
-            os.write(String.format("\tcp %s %s/%s\n", starterPath, tmpPath, starterName));
-            os.write(String.format("\tchmod +x %s/%s\n", tmpPath, starterName));
-            os.write(String.format("\texport PATH=%s:/system/bin:$PATH\n", tmpPath));
-            os.write(String.format("\t%s\n", starterName));
-
-            os.write("else\n");
-            os.write("\techo \"Apk file not exist, please open Shizuku Manager and try again.\"\n");
-            os.write("fi\n");
+            BufferedReader is = new BufferedReader(new InputStreamReader(context.getResources().openRawResource(R.raw.start)));
+            PrintWriter os = new PrintWriter(new FileWriter(file));
+            String line;
+            while ((line = is.readLine()) != null) {
+                os.println(line.replace("%%%STARTER_PATH%%%", starterPath));
+            }
             os.flush();
             os.close();
         } catch (Exception ignored) {

--- a/manager/src/main/jni/CMakeLists.txt
+++ b/manager/src/main/jni/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.4.1)
 
+# build executable files to manager/build/starter/<arch>/libshizuku.so, which is
+# set as jniLibs.srcDirs in manager/build.gradle.
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/../../../build/starter/${ANDROID_ABI})
 
 add_executable( libshizuku.so

--- a/manager/src/main/jni/CMakeLists.txt
+++ b/manager/src/main/jni/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.4.1)
+
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/../../../build/starter/${ANDROID_ABI})
+
+add_executable( libshizuku.so
+                starter.c )

--- a/manager/src/main/jni/starter.c
+++ b/manager/src/main/jni/starter.c
@@ -6,9 +6,22 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <dirent.h>
+#include <signal.h>
+#include <stdint.h>
 
 #define TRUE 1
 #define FALSE 0
+
+#define EXIT_FATAL_PM_PATH 1
+#define EXIT_FATAL_PM_PATH_MALFORMED 2
+#define EXIT_FATAL_SET_CLASSPATH 3
+#define EXIT_FATAL_FORK 4
+#define EXIT_FATAL_APP_PROCESS 5
+#define EXIT_WARN_OPEN_PROC 6
+#define EXIT_WARN_START_TIMEOUT 7
+#define EXIT_WARN_SERVER_STOP 8
+#define ExIT_FATAL_KILL_OLD_SERVER 9
 
 char *trimCRLF(char *str) {
     char *p;
@@ -29,28 +42,89 @@ char *getApkPath(char *buffer) {
         fgets(buffer, (PATH_MAX + 11) * sizeof(char), file);
     } else {
         perror("fatal: can't invoke `pm path'\n");
-        exit(1);
+        fflush(stderr);
+        exit(EXIT_FATAL_PM_PATH);
     }
     trimCRLF(buffer);
     buffer = strchr(buffer, ':');
     if (buffer == NULL) {
         perror("fatal: can't get apk path, have you installed Shizuku Manager? Get it from https://play.google.com/store/apps/details?id=moe.shizuku.privileged.api\n");
-        exit(2);
+        fflush(stderr);
+        exit(EXIT_FATAL_PM_PATH_MALFORMED);
     }
     buffer++;
     printf("info: apk installed path: %s\n", buffer);
+    fflush(stdout);
     return buffer;
 }
 
 void setClasspathEnv(char *path) {
     if (setenv("CLASSPATH", path, TRUE)) {
         perror("fatal: can't set CLASSPATH\n");
-        exit(3);
+        fflush(stderr);
+        exit(EXIT_FATAL_SET_CLASSPATH);
     }
     printf("info: CLASSPATH=%s\n", path);
+    fflush(stdout);
+}
+
+pid_t getRikkaServerPid() {
+    DIR *procDir = opendir("/proc");
+    if (procDir != NULL) {
+        struct dirent *pidDirent;
+        while ((pidDirent = readdir(procDir)) != NULL) {
+            uint32_t pid = (uint32_t) atoi(pidDirent->d_name);
+            if (pid != 0) {  // skip non number directory or files
+                char cmdlinePath[PATH_MAX];
+                sprintf(cmdlinePath, "/proc/%d/cmdline", pid);
+                cmdlinePath[PATH_MAX - 1] = '\0';
+                FILE *cmdlineFile;
+                if ((cmdlineFile = fopen(cmdlinePath, "r")) != NULL) {
+                    char cmdline[50];
+                    fread(cmdline, 1, 50, cmdlineFile);
+                    cmdline[49] = '\0';
+                    fclose(cmdlineFile);
+                    if (strstr(cmdline, "rikka_server") != NULL) {
+                        return (pid_t) pid;
+                    }
+                }
+            }
+        }
+        return 0;
+    } else {
+        perror("\nwarn: can't open /proc, please check by yourself.\n");
+        fflush(stderr);
+        exit(EXIT_WARN_OPEN_PROC);
+    }
+}
+
+void killOldServer() {
+    pid_t pid = getRikkaServerPid();
+    if (pid != 0) {
+        printf("info: old rikka_server found, killing\n");
+        fflush(stdout);
+        if (kill(pid, SIGINT) != 0) {
+            perror("fatal: can't kill old server, if you started it by root, please invoke this command:\n\n\t\t");
+            fflush(stderr);
+            char killByRootCommand[100];
+            sprintf(killByRootCommand, "adb shell su -c \"kill %d\"", pid);
+            killByRootCommand[99] = '\0';
+            perror(killByRootCommand);
+            fflush(stderr);
+            perror("\n\n");
+            fflush(stderr);
+            exit(ExIT_FATAL_KILL_OLD_SERVER);
+        }
+    } else {
+        printf("info: no old rikka_server found.\n");
+        fflush(stdout);
+    }
 }
 
 int main(int argc, char **argv) {
+    printf("info: starter begin\n");
+    fflush(stdout);
+    killOldServer();
     char buffer[PATH_MAX + 11];
     char *path = getApkPath(buffer);
     pid_t pid = fork();
@@ -64,13 +138,51 @@ int main(int argc, char **argv) {
                 NULL
         };
         if (execvp(appProcessArgs[0], appProcessArgs)) {
-            perror("fatal: can't invoke app_process\n");
-            exit(5);
+            char err[100];
+            sprintf(err, "fatal: can't invoke app_process, errno=%d\n", errno);
+            err[99] = '\0';
+            perror(err);
+            fflush(stderr);
+            exit(EXIT_FATAL_APP_PROCESS);
         }
     } else if (pid == -1) {
         perror("fatal: can't fork\n");
-        exit(4);
+        fflush(stderr);
+        exit(EXIT_FATAL_FORK);
     } else {
-        exit(0);
+        printf("info: child process forked, pid=%d\n", pid);
+        fflush(stdout);
+        printf("info: check rikka_server start\n");
+        fflush(stdout);
+        int rikkaServerPid;
+        int count = 0;
+        while ((rikkaServerPid = getRikkaServerPid()) == 0) {
+            printf(".");
+            fflush(stdout);
+            sleep(1);
+            count++;
+            if (count > 10) {
+                perror("\nwarn: timeout but can't get pid of rikka_server.\n");
+                fflush(stderr);
+                exit(EXIT_WARN_START_TIMEOUT);
+            }
+        }
+        printf("\ninfo: check rikka_server stable\n");
+        fflush(stdout);
+        count = 0;
+        while ((rikkaServerPid = getRikkaServerPid()) != 0) {
+            printf(".");
+            fflush(stdout);
+            sleep(1);
+            count++;
+            if (count > 5) {
+                printf("\ninfo: rikka_server started.");
+                fflush(stdout);
+                exit(EXIT_SUCCESS);
+            }
+        }
+        perror("\nwarn: rikka_server stopped after started.\n");
+        fflush(stderr);
+        exit(EXIT_WARN_SERVER_STOP);
     }
 }

--- a/manager/src/main/jni/starter.c
+++ b/manager/src/main/jni/starter.c
@@ -1,0 +1,76 @@
+//
+// Created by haruue on 17-6-28.
+//
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define TRUE 1
+#define FALSE 0
+
+char *trimCRLF(char *str) {
+    char *p;
+    p = strchr(str, '\r');
+    if (p != NULL) {
+        *p = '\0';
+    }
+    p = strchr(str, '\n');
+    if (p != NULL) {
+        *p = '\0';
+    }
+    return str;
+}
+
+char *getApkPath(char *buffer) {
+    FILE *file = popen("pm path moe.shizuku.privileged.api", "r");
+    if (file != NULL) {
+        fgets(buffer, (PATH_MAX + 11) * sizeof(char), file);
+    } else {
+        perror("fatal: can't invoke `pm path'\n");
+        exit(1);
+    }
+    trimCRLF(buffer);
+    buffer = strchr(buffer, ':');
+    if (buffer == NULL) {
+        perror("fatal: can't get apk path, have you installed Shizuku Manager? Get it from https://play.google.com/store/apps/details?id=moe.shizuku.privileged.api\n");
+        exit(2);
+    }
+    buffer++;
+    printf("info: apk installed path: %s\n", buffer);
+    return buffer;
+}
+
+void setClasspathEnv(char *path) {
+    if (setenv("CLASSPATH", path, TRUE)) {
+        perror("fatal: can't set CLASSPATH\n");
+        exit(3);
+    }
+    printf("info: CLASSPATH=%s\n", path);
+}
+
+int main(int argc, char **argv) {
+    char buffer[PATH_MAX + 11];
+    char *path = getApkPath(buffer);
+    pid_t pid = fork();
+    if (pid == 0) {
+        setClasspathEnv(path);
+        char *appProcessArgs[] = {
+                "/system/bin/app_process",
+                "/system/bin",
+                "--nice-name=rikka_server",
+                "moe.shizuku.server.Server",
+                NULL
+        };
+        if (execvp(appProcessArgs[0], appProcessArgs)) {
+            perror("fatal: can't invoke app_process\n");
+            exit(5);
+        }
+    } else if (pid == -1) {
+        perror("fatal: can't fork\n");
+        exit(4);
+    } else {
+        exit(0);
+    }
+}

--- a/manager/src/main/jni/starter.c
+++ b/manager/src/main/jni/starter.c
@@ -7,12 +7,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <dirent.h>
-#include <signal.h>
-#include <stdint.h>
-#include <limits.h>
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 
 #define TRUE 1
 #define FALSE 0
@@ -26,7 +20,6 @@
 #define EXIT_WARN_START_TIMEOUT 7
 #define EXIT_WARN_SERVER_STOP 8
 #define ExIT_FATAL_KILL_OLD_SERVER 9
-#define EXIT_FATAL_SET_SID 10
 
 #define LOG_FILE_PATH "/data/local/tmp/rikka_server_starter.log"
 

--- a/manager/src/main/res/raw/start.sh
+++ b/manager/src/main/res/raw/start.sh
@@ -1,0 +1,13 @@
+#!/system/bin/sh
+
+STARTER_PATH=%%%STARTER_PATH%%%
+
+if [ -f "$STARTER_PATH" ]; then
+    rm /data/local/tmp/shizuku_starter 2> /dev/null
+    cp "$STARTER_PATH" /data/local/tmp/shizuku_starter
+    chmod +x /data/local/tmp/shizuku_starter
+    export PATH=/data/local/tmp:/system/bin:$PATH
+    shizuku_starter
+else
+    echo "Starter file not exist, please open Shizuku Manager and try again."
+fi

--- a/manager/src/main/res/raw/start.sh
+++ b/manager/src/main/res/raw/start.sh
@@ -2,12 +2,17 @@
 
 STARTER_PATH=%%%STARTER_PATH%%%
 
+echo "info: start.sh begin"
+
 if [ -f "$STARTER_PATH" ]; then
     rm /data/local/tmp/shizuku_starter 2> /dev/null
     cp "$STARTER_PATH" /data/local/tmp/shizuku_starter
     chmod +x /data/local/tmp/shizuku_starter
     export PATH=/data/local/tmp:/system/bin:$PATH
     shizuku_starter
+    if [ $? -ne 0 ]; then
+        echo "shizuku_starter exit with non-zero value $?"
+    fi
 else
     echo "Starter file not exist, please open Shizuku Manager and try again."
 fi


### PR DESCRIPTION
~~prpr Rikka~~
### 概览
使用 [`daemon()`](http://man7.org/linux/man-pages/man3/daemon.3.html) 启动 Shizuku Server ，类似于 nohup 了，应该可以解决之前纯 Shell 启动产生的某些奇奇怪怪的问题。。。

### 编译方法
在我这儿 Android Studio 一直都不能正常编译这个工程。。所以我是这样编译的
``` shell
# start in project directory
cd generator
gradle build
cd ..
gradle build
# APK files can be found in manager/build/outputs/apk/manager-*.apk , 
# or use gradle installRelease to install it to connected device directly.
```
注意确保编译完成之后 apk 文件中含有 `lib/<arch>/libshizuku.so` ，不然打开就会崩。。。
**如果发现编译之后不能产生正常的 apk 文件请不要合并**

~~应该还有些坑不过可以正常工作，文案什么的 Rikka 自己改吧~~